### PR TITLE
INT-139

### DIFF
--- a/integration.js
+++ b/integration.js
@@ -93,7 +93,8 @@ function doLookup(entities, options, cb) {
       } else{
         let exactMatches = []
         result.body.forEach(match => {
-          if (match.meta.stems.includes(result.entity.value.toLowerCase())) {
+          let lowerStems = match.meta.stems.map(stem => stem.toLowerCase());
+          if (lowerStems.includes(result.entity.value)) {
             exactMatches.push({
                 type: match.fl,
                 defs: match.shortdef,

--- a/templates/block.hbs
+++ b/templates/block.hbs
@@ -3,13 +3,17 @@
     <br><br>
     {{#each details as |detail|}}
         <p>Entry: <b>{{detail.hw}}</b></p>
-        <p>Usage: <b>{{detail.type}}</b></p>
-        <p>Definitions:</p>
-        <ol>
-            {{#each detail.defs as |def|}}
-                <li><b>{{def}}</b></li>
-            {{/each}}
-        </ol>
+        {{#if detail.type}}
+            <p>Usage: <b>{{detail.type}}</b></p>
+        {{/if}}
+        {{#if detail.defs}}
+            <p>Definitions:</p>
+            <ol>
+                {{#each detail.defs as |def|}}
+                    <li><b>{{def}}</b></li>
+                {{/each}}
+            </ol>
+        {{/if}}
         <br>
     {{/each}}
 </div>


### PR DESCRIPTION
- It was assumed that all stems returned from the API were all lower case. However, for proper nouns, this is not the case. So, since we search for unique lowercase entities, I also quickly convert all the stems to lowercase to look for matches as well.

- Additional fix for when we don't get a usage or definition returned to us that part of the template isn't added to the card. For example, if you searched for "do", you'd also get all the archaic versions like "dost" and "didst" - this would create an entry where the Usage and Definition was blank. Now it simply states that an entry was found without rendering blank attributes.